### PR TITLE
Integrate OpenAI API for 3–4 line disease description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 test
 train
 valid
+.env

--- a/disease_info.py
+++ b/disease_info.py
@@ -1,0 +1,39 @@
+from dotenv import load_dotenv
+load_dotenv()  # loads .env
+
+import os
+from openai import OpenAI
+
+def get_openai_client():
+    api_key = os.getenv("OPENAI_API_KEY") 
+    if not api_key:
+        return None
+    return OpenAI(api_key=api_key)
+
+def fetch_description(disease_name, client=None):
+    if client is None:
+        client = get_openai_client()
+    if client is None:
+        return "OpenAI API key missing; cannot fetch description."
+
+    # Make the disease label more readable
+    readable_name = disease_name.replace("___", " ").replace("_", " ")
+
+    prompt = (
+        f"You are an expert plant pathologist. Give a short, clear description of the plant disease "
+        f"'{readable_name}', including typical symptoms and prevention tips. Keep it concise (3–4 sentences)."
+    )
+
+    try:
+        response = client.chat.completions.create(
+            model="gpt-4o-mini",
+            messages=[
+                {"role": "system", "content": "You are an expert in plant diseases and crop health."},
+                {"role": "user", "content": prompt}
+            ],
+            max_tokens=180,
+            temperature=0.4,
+        )
+        return response.choices[0].message.content.strip()
+    except Exception as e:
+        return f"(Failed to fetch description from OpenAI: {e})"

--- a/main.py
+++ b/main.py
@@ -1,77 +1,28 @@
-#Importing libraries
+import os
 import streamlit as st
 import tensorflow as tf
 import numpy as np
+from disease_info import fetch_description, get_openai_client
+from PIL import Image
 
-#Tensorflow midel Prediction function
-#In this function we juct have to upload our image and it will predict the disease it have
+# Load OpenAI client once
+client = get_openai_client()
+
+# TensorFlow model prediction function (using PIL for uploaded file)
 def model_prediction(test_image):
-    model  = tf.keras.models.load_model('trained_model.keras')
-    image = tf.keras.preprocessing.image.load_img(test_image,target_size=(128, 128))
-    input_arr = tf.keras.preprocessing.image.img_to_array(image)
-    input_arr = np.array([input_arr]) #Convert single image to a batch
+    model = tf.keras.models.load_model('trained_model.keras')
+    # Streamlit UploadedFile supports .read(); open with PIL then convert
+    pil_img = Image.open(test_image).convert("RGB")
+    pil_img = pil_img.resize((128, 128))
+    input_arr = tf.keras.preprocessing.image.img_to_array(pil_img)
+    input_arr = np.expand_dims(input_arr, axis=0)  # batch dimension
     prediction = model.predict(input_arr)
-    result_index = np.argmax(prediction)
+    result_index = int(np.argmax(prediction))
     return result_index
 
-#creating Sidebar of website
-st.sidebar.title("Dashboard")
-app_mode = st.sidebar.selectbox("Select Page",["Home","About","Disease Recognition"])
-
-#Home Page
-if(app_mode=="Home"):  #if we have selected this then trigger Home page
-    st.header("PLANT DISEASE RECOGNITION SYSTEM")
-    image_path="Leaf Image.jpeg"
-    st.image(image_path,use_column_width=True)
-    st.markdown("""
-    Welcome to the Plant Disease Recognition System! 🌿🔍
-    
-    Our mission is to help in identifying plant diseases efficiently. Upload an image of a plant, and our system will analyze it to detect any signs of diseases. Together, let's protect our crops and ensure a healthier harvest!
-
-    ### How It Works 
-    1. **Upload Image:** Go to the **Disease Recognition** page in the Sidebar and upload an image of a plant with suspected diseases.
-    2. **Analysis:** Our system will process the image using advanced algorithms to identify potential diseases.
-    3. **Results:** View the results and recommendations for further action.
-
-    ### Why Choose Us?
-    - **Accuracy:** Our system utilizes Deep learning techniques for accurate disease detection.
-    - **User-Friendly:** Simple and intuitive interface for seamless user experience.
-    - **Fast and Efficient:** Receive results in seconds, allowing for quick decision-making.
-
-    ### Get Started
-    Click on the **Disease Recognition** page in the sidebar to upload an image and experience the power of our Plant Disease Recognition System!
-
-    ### About Us
-    Learn more about the project, our team, and our goals on the **About** page.
-""")
-
- # Creating About Page
-elif(app_mode=="About"):
-    st.header("About")
-    image_path="dataset-Image.png"
-    st.image(image_path,use_column_width=True)    
-    st.markdown("""
-    #### About Dataset
-    This dataset is recreated using offline augmentation from the original dataset. The original dataset can be found on this github repo. This dataset consists of about 87K rgb images of healthy and diseased crop leaves which is categorized into 38 different classes. The total dataset is divided into 80/20 ratio of training and validation set preserving the directory structure. A new directory containing 33 test images is created later for prediction purpose.
-    #### Content
-    1. Train (70295 images)
-    2. Valid (17572 image)
-    3. Test (33 images)
-""")
-    
- #Creating Prediction Page
-elif(app_mode=="Disease Recognition"):
-    st.header("Disease Recognition")
-    test_image = st.file_uploader("Choose an Image:")
-    if(st.button("Show Image")):
-        st.image(test_image,use_column_width=True)
-    #Predict Button
-    if(st.button("Predict")):
-        with st.spinner("Please Wait.."):
-            st.write("Our Prediction")
-            result_index = model_prediction(test_image)
-            #Define Class
-            class_name = ['Apple___Apple_scab',
+# Disease classes (must match model's output ordering)
+CLASS_NAME = [
+    'Apple___Apple_scab',
     'Apple___Black_rot',
     'Apple___Cedar_apple_rust',
     'Apple___healthy',
@@ -108,5 +59,89 @@ elif(app_mode=="Disease Recognition"):
     'Tomato___Target_Spot',
     'Tomato___Tomato_Yellow_Leaf_Curl_Virus',
     'Tomato___Tomato_mosaic_virus',
-    'Tomato___healthy']
-        st.success("Model is Predicting it's a {}".format(class_name[result_index]))
+    'Tomato___healthy'
+]
+
+def humanize_label(raw_label: str) -> str:
+    return raw_label.replace("___", " ").replace("_", " ")
+
+# Sidebar and navigation
+st.sidebar.title("Dashboard")
+app_mode = st.sidebar.selectbox("Select Page", ["Home", "About", "Disease Recognition"])
+
+if app_mode == "Home":
+    st.header("PLANT DISEASE RECOGNITION SYSTEM")
+    image_path = "Leaf Image.jpeg"
+    st.image(image_path, use_container_width=True)
+    st.markdown("""
+    Welcome to the Plant Disease Recognition System! 🌿🔍
+
+    Our mission is to help in identifying plant diseases efficiently. Upload an image of a plant, and our system will analyze it to detect any signs of diseases. Together, let's protect our crops and ensure a healthier harvest!
+
+    ### How It Works 
+    1. **Upload Image:** Go to the **Disease Recognition** page in the Sidebar and upload an image of a plant with suspected diseases.
+    2. **Analysis:** Our system will process the image using advanced algorithms to identify potential diseases.
+    3. **Results:** View the results and recommendations for further action.
+
+    ### Why Choose Us?
+    - **Accuracy:** Our system utilizes Deep learning techniques for accurate disease detection.
+    - **User-Friendly:** Simple and intuitive interface for seamless user experience.
+    - **Fast and Efficient:** Receive results in seconds, allowing for quick decision-making.
+
+    ### Get Started
+    Click on the **Disease Recognition** page in the sidebar to upload an image and experience the power of our Plant Disease Recognition System!
+    """)
+
+elif app_mode == "About":
+    st.header("About")
+    image_path = "dataset-Image.png"
+    st.image(image_path, use_container_width=True)
+    st.markdown("""
+    #### About Dataset
+    This dataset is recreated using offline augmentation from the original dataset. The original dataset can be found on this GitHub repo. This dataset consists of about 87K RGB images of healthy and diseased crop leaves which are categorized into 38 different classes. The total dataset is divided into an 80/20 ratio of training and validation sets preserving the directory structure. A new directory containing 33 test images is created later for prediction purposes.
+
+    #### Content
+    1. Train (70295 images)  
+    2. Valid (17572 images)  
+    3. Test (33 images)
+    """)
+
+elif app_mode == "Disease Recognition":
+    st.header("Disease Recognition")
+
+    # Warn if OpenAI key missing
+    if client is None:
+        st.warning("OPENAI_API_KEY is not set; disease descriptions will not be fetched from OpenAI.")
+
+    test_image = st.file_uploader("Choose an Image:", type=["jpg", "jpeg", "png"])
+    if test_image:
+        st.image(test_image, use_container_width=True)
+
+    if st.button("Predict"):
+        if not test_image:
+            st.error("Please upload an image first.")
+        else:
+            with st.spinner("Predicting disease and fetching description..."):
+                try:
+                    result_index = model_prediction(test_image)
+                except Exception as e:
+                    st.error(f"Model prediction failed: {e}")
+                    st.stop()
+
+                if result_index < 0 or result_index >= len(CLASS_NAME):
+                    st.error("Model output index out of range.")
+                    st.stop()
+
+                predicted_raw = CLASS_NAME[result_index]
+                readable = humanize_label(predicted_raw)
+                st.success(f"Model is predicting it's: {readable}")
+
+                # Fetch description, with timeout safety
+                try:
+                    description = fetch_description(predicted_raw, client=client)
+                    if not description:
+                        st.warning("Received empty description from OpenAI.")
+                    st.markdown(f"### About {readable}")
+                    st.write(description)
+                except Exception as ex:
+                    st.error(f"Failed to get description: {ex}")


### PR DESCRIPTION
Added disease_info.py to handle OpenAI API calls for plant disease descriptions.

Integrated model prediction results with OpenAI API to fetch concise (3–4 line) descriptions of predicted diseases.

Updated main.py to display a “Know about this disease” section after prediction.

Ensured .env is in .gitignore to protect API keys.

